### PR TITLE
Fixes TypeLoadException from incorrect overrides.

### DIFF
--- a/Discord.Interactive/Criteria/NextMessageCriteria.cs
+++ b/Discord.Interactive/Criteria/NextMessageCriteria.cs
@@ -17,16 +17,16 @@ namespace Discord.Interactive
         internal NextMessageCriteria(ulong? userId, ulong? channelId)
             : base(userId, channelId) { }
 
-        public override NextMessageCriteria EnsureUser(ulong id)
+        public override UserChannelCriteria<IMessage> EnsureUser(ulong id)
             => new NextMessageCriteria(id, RequiredChannelId);
 
-        public override NextMessageCriteria EnsureUser(IUser user)
+        public override UserChannelCriteria<IMessage> EnsureUser(IUser user)
             => new NextMessageCriteria(user.Id, RequiredChannelId);
 
-        public override NextMessageCriteria EnsureChannel(ulong id)
+        public override UserChannelCriteria<IMessage> EnsureChannel(ulong id)
             => new NextMessageCriteria(RequiredUserId, id);
 
-        public override NextMessageCriteria EnsureChannel(IChannel channel)
+        public override UserChannelCriteria<IMessage> EnsureChannel(IChannel channel)
             => new NextMessageCriteria(RequiredUserId, channel.Id);
 
         public override Task<bool> ValidateAsync(IMessage message)

--- a/Discord.Interactive/Criteria/NextReactionCriteria.cs
+++ b/Discord.Interactive/Criteria/NextReactionCriteria.cs
@@ -28,16 +28,16 @@ namespace Discord.Interactive
             RequiredReactions = reactions?.ToList();
         }
 
-        public override NextReactionCriteria EnsureUser(ulong id)
+        public override UserChannelCriteria<ReactionEventData> EnsureUser(ulong id)
             => new NextReactionCriteria(id, RequiredChannelId, RequiredMessageId, RequiredReactions);
 
-        public override NextReactionCriteria EnsureUser(IUser user)
+        public override UserChannelCriteria<ReactionEventData> EnsureUser(IUser user)
             => EnsureUser(user.Id);
 
-        public override NextReactionCriteria EnsureChannel(ulong id)
+        public override UserChannelCriteria<ReactionEventData> EnsureChannel(ulong id)
             => new NextReactionCriteria(RequiredUserId, id, RequiredMessageId, RequiredReactions);
 
-        public override NextReactionCriteria EnsureChannel(IChannel channel)
+        public override UserChannelCriteria<ReactionEventData> EnsureChannel(IChannel channel)
             => EnsureChannel(channel.Id);
 
         public NextReactionCriteria EnsureEmotes(params IEmote[] emotes)


### PR DESCRIPTION
This PR fixes `System.TypeLoadException` when resolving `ICriteria` overrides apparent when using `Interative.NextMessageAsync`.